### PR TITLE
change condition oder in getAllAuthItemsRole() for User with allAuthI…

### DIFF
--- a/src/ActiveRecordAccessTrait.php
+++ b/src/ActiveRecordAccessTrait.php
@@ -223,21 +223,21 @@ trait ActiveRecordAccessTrait
 
                 $allRoles = $authManager->getRoles();
 
-                if (!static::isEnabledRecursiveRoles()) {
-                    if (Yii::$app->user->can(self::getAllAuthItemsRole())) {
-                        // when user is 'Admin' use all roles
-                        $roles = $allRoles;
-                    } else {
-                        // only use directly assigned roles
-                        $roles = $authManager->getRolesByUser(Yii::$app->user->id);
-                    }
+                // when user is 'Admin' use all roles
+                if (Yii::$app->user->can(self::getAllAuthItemsRole())) {
+                    $roles = $allRoles;
                 } else {
-                    // check all roles
-                    $roles = [];
-                    foreach ($allRoles as $roleItem) {
-                        $roleName = $roleItem->name;
-                        if (Yii::$app->user->can($roleName)) {
-                            $roles[$roleName] = $roleItem;
+                    if (!static::isEnabledRecursiveRoles()) {
+                        // only direct assigned roles
+                        $roles = $authManager->getRolesByUser(Yii::$app->user->id);
+                    } else {
+                        // check all roles
+                        $roles = [];
+                        foreach ($allRoles as $roleItem) {
+                            $roleName = $roleItem->name;
+                            if (Yii::$app->user->can($roleName)) {
+                                $roles[$roleName] = $roleItem;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR change the condition oder in `getAllAuthItemsRole()` for User with `allAuthItemsRole`

- if User has the role defined as `allAuthItemsRole` (Admin per default) then we should always return allRoles. 
- currently this is only checked (and done) when `isEnabledRecursiveRoles == false` which IMHO makes no sense.



| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


