### PR TITLE
Disable access role inputs if there is a value set which is not in list of given values

### DIFF
--- a/src/AccessInput.php
+++ b/src/AccessInput.php
@@ -42,9 +42,6 @@ class AccessInput extends Widget
             ->textInput(['readonly' => true]); // TODO: Check owner in model (has to be the same as current user)
 
         foreach (['domain', 'read', 'update', 'delete'] as $access) {
-            // save the current value in disabled because we may rewrite it if value is not in data
-            $originalDisabled = $disabled;
-
             $data = $access === 'domain' ? $userDomains : $userAuthItems;
             $fieldName = 'field' . ucfirst($access);
 
@@ -52,7 +49,6 @@ class AccessInput extends Widget
             // Check if value set is in data list and add it if its not and disable the input
             if (!array_key_exists($value, $data)) {
                 $data[$value] = $value;
-                $disabled = !Yii::$app->getUser()->can($value); // Check if current user is able to modify the value
             }
 
             $return .= $this->form->field($this->model, $this->$fieldName)->widget(
@@ -66,9 +62,6 @@ class AccessInput extends Widget
                     ]
                 ]
             );
-
-            // Reset disabled value if reset from value exists check
-            $disabled = $originalDisabled;
         }
         return $return;
     }

--- a/src/AccessInput.php
+++ b/src/AccessInput.php
@@ -52,7 +52,7 @@ class AccessInput extends Widget
             // Check if value set is in data list and add it if its not and disable the input
             if (!array_key_exists($vaule, $data)) {
                 $data[$vaule] = $vaule;
-                $disabled = true;
+                $disabled = !Yii::$app->getUser()->can($vaule); // Check if current user is able to modify the value
             }
 
             $return .= $this->form->field($this->model, $this->$fieldName)->widget(

--- a/src/AccessInput.php
+++ b/src/AccessInput.php
@@ -59,7 +59,7 @@ class AccessInput extends Widget
                 Select2::class,
                 [
                     'data' => $data,
-                    'options' => ['placeholder' => Yii::t('pages', 'Select ...')],
+                    'options' => ['placeholder' => Yii::t('app', 'Select ...')],
                     'pluginOptions' => [
                         'allowClear' => true,
                         'disabled' => $disabled

--- a/src/AccessInput.php
+++ b/src/AccessInput.php
@@ -46,9 +46,9 @@ class AccessInput extends Widget
             $fieldName = 'field' . ucfirst($access);
 
             $value = $this->model->{$this->$fieldName};
-            // Check if value set is in data list and add it if its not and disable the input
+            // Check if value set is in data list and add it if its not
             if (!array_key_exists($value, $data)) {
-                $data[$value] = $value;
+                $data[$value] = Yii::t('app', '{roleName}*', ['roleName' => $value]);
             }
 
             $return .= $this->form->field($this->model, $this->$fieldName)->widget(
@@ -62,6 +62,7 @@ class AccessInput extends Widget
                     ]
                 ]
             );
+
         }
         return $return;
     }

--- a/src/AccessInput.php
+++ b/src/AccessInput.php
@@ -48,11 +48,11 @@ class AccessInput extends Widget
             $data = $access === 'domain' ? $userDomains : $userAuthItems;
             $fieldName = 'field' . ucfirst($access);
 
-            $vaule = $this->model->{$this->$fieldName};
+            $value = $this->model->{$this->$fieldName};
             // Check if value set is in data list and add it if its not and disable the input
-            if (!array_key_exists($vaule, $data)) {
-                $data[$vaule] = $vaule;
-                $disabled = !Yii::$app->getUser()->can($vaule); // Check if current user is able to modify the value
+            if (!array_key_exists($value, $data)) {
+                $data[$value] = $value;
+                $disabled = !Yii::$app->getUser()->can($value); // Check if current user is able to modify the value
             }
 
             $return .= $this->form->field($this->model, $this->$fieldName)->widget(


### PR DESCRIPTION
The aim of this is to solve the specific problem that if a user does not have the role assigned in the input field, the value of the attribute behind this field is set to NULL.

| Q             | A
| ------------- | ---
| Is bugfix?    | Yes
| New feature?  | No
| Breaks BC?    | No
| Tests pass?   | Where there are no tests, they cannot pass
