### PR TITLE
Make user id for owner checks modifiable

### DIFF
--- a/src/ActiveRecordAccessTrait.php
+++ b/src/ActiveRecordAccessTrait.php
@@ -290,7 +290,7 @@ trait ActiveRecordAccessTrait
     /**
      * @return bool|mixed
      */
-    public static function isEnabledRecursiveRoles() {
+    public static function isEnabledRecursiveRoles () {
         return Yii::$app->params['ActiveRecordAccessTrait']['enableRecursiveRoles'] ?? static::$enableRecursiveRoles;
     }
 
@@ -347,6 +347,7 @@ trait ActiveRecordAccessTrait
 
     /**
      * Decode access column by action from csv to array
+     *
      * @param string $action
      * @param array $authItems
      *
@@ -363,7 +364,6 @@ trait ActiveRecordAccessTrait
 
     /**
      * Encode access column by action from csv to array
-     *
      * @param $action
      *
      * @return array|null

--- a/src/ActiveRecordAccessTrait.php
+++ b/src/ActiveRecordAccessTrait.php
@@ -9,8 +9,8 @@
 
 namespace dmstr\activeRecordPermissions;
 
-use dmstr\db\exceptions\UnsupportedDbException;
 use Yii;
+use dmstr\db\exceptions\UnsupportedDbException;
 use yii\console\Application as ConsoleApplication;
 use yii\helpers\StringHelper;
 
@@ -24,28 +24,24 @@ trait ActiveRecordAccessTrait
 {
     /**
      * Use session flash messages
-     *
      * @var bool
      */
     public static $enableFlashMessages = true;
 
     /**
      * Active find, beforeSave, beforeDelete
-     *
      * @var bool
      */
     public static $activeAccessTrait = true;
 
     /**
      * Enable/disable recursive role check
-     *
      * @var bool
      */
     public static $enableRecursiveRoles = false;
 
     /**
      * Public / all access
-     *
      * @var string
      */
     public static $_all = '*';
@@ -74,8 +70,8 @@ trait ActiveRecordAccessTrait
         // use prefix to avoid ambigious column names
         $prefix = self::getTableSchema()->name;
         return [
-            'owner' => "{$prefix}.access_owner",
-            'read' => "{$prefix}.access_read",
+            'owner'  => "{$prefix}.access_owner",
+            'read'   => "{$prefix}.access_read",
             'update' => "{$prefix}.access_update",
             'delete' => "{$prefix}.access_delete",
             'domain' => "{$prefix}.access_domain",
@@ -105,8 +101,8 @@ trait ActiveRecordAccessTrait
             return $query;
         }
 
-        $accessOwner = self::accessColumnAttributes()['owner'];
-        $accessRead = self::accessColumnAttributes()['read'];
+        $accessOwner  = self::accessColumnAttributes()['owner'];
+        $accessRead   = self::accessColumnAttributes()['read'];
         $accessDomain = self::accessColumnAttributes()['domain'];
 
         if (self::$activeAccessTrait) {
@@ -215,7 +211,6 @@ trait ActiveRecordAccessTrait
 
     /**
      * Returns roles *assigned* to current user or all roles for admin
-     *
      * @return array with item names
      */
     public static function getUsersAuthItems()
@@ -295,13 +290,11 @@ trait ActiveRecordAccessTrait
     /**
      * @return bool|mixed
      */
-    public static function isEnabledRecursiveRoles()
-    {
+    public static function isEnabledRecursiveRoles() {
         return Yii::$app->params['ActiveRecordAccessTrait']['enableRecursiveRoles'] ?? static::$enableRecursiveRoles;
     }
 
-    public static function getDefaultAccessDomain()
-    {
+    public static function getDefaultAccessDomain() {
         // return first found permission
         $AuthManager = \Yii::$app->authManager;
         $permissions = $AuthManager->getPermissionsByUser(Yii::$app->user->id);
@@ -323,8 +316,7 @@ trait ActiveRecordAccessTrait
     /**
      * @return null,string default access permission for user
      */
-    public static function getDefaultAccessUpdateDelete()
-    {
+    public static function getDefaultAccessUpdateDelete() {
 
         // allow setting `null` for eg. Admins
         if (Yii::$app->user->can('access.defaults.updateDelete:null')) {
@@ -355,7 +347,6 @@ trait ActiveRecordAccessTrait
 
     /**
      * Decode access column by action from csv to array
-     *
      * @param string $action
      * @param array $authItems
      *
@@ -407,7 +398,7 @@ trait ActiveRecordAccessTrait
         }
 
         // owner check (has all permissions)
-        $accessOwner = self::accessColumnAttributes()['owner'];
+        $accessOwner  = self::accessColumnAttributes()['owner'];
         if ($accessOwner) {
             if (!\Yii::$app->user->isGuest && $this->getOldAttribute($this->getSchemaProperty($accessOwner)) == static::currentUserId()) {
                 return true;
@@ -415,7 +406,7 @@ trait ActiveRecordAccessTrait
         }
 
         // allow, if permission is "*"
-        $column = $this->getSchemaProperty($action);
+        $column =  $this->getSchemaProperty($action);
         if ($this->getOldAttribute($column) === self::$_all) {
             return true;
         }
@@ -450,16 +441,14 @@ trait ActiveRecordAccessTrait
 
     /**
      * Return correct part of check in set  query for current DB
-     *
      * @param $accessRead
      * @param $authItems
-     *
      * @return string|array
      */
     private static function getInSetQueryPart($accessRead, $authItems)
     {
         $dbName = Yii::$app->db->getDriverName();
-        switch ($dbName) {
+        switch($dbName) {
             case 'mysql':
                 return 'FIND_IN_SET(' . $accessRead . ', "' . $authItems . '") > 0';
             case 'pgsql':
@@ -470,8 +459,7 @@ trait ActiveRecordAccessTrait
     }
 
     // extract property from table name with schema
-    private function getSchemaProperty($schemaProperty)
-    {
+    private function getSchemaProperty($schemaProperty){
         // extract property from table name with schema
         if (strstr($schemaProperty, '.')) {
             $prop = substr($schemaProperty, strrpos($schemaProperty, '.') + 1);


### PR DESCRIPTION
As the user component method `getId()` gets its value from the user identity and the value could also come from another column as we can reference the user by whatever we want. We should make id more flexible

| Q             | A
| ------------- | ---
| Is bugfix?    | No
| New feature?  | Yes
| Breaks BC?    | No
| Tests pass?   | Where there are no tests, they cannot pass
